### PR TITLE
docs: add make test to README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,5 +167,6 @@ git clone https://github.com/RJNY/Obtainium-Emulation-Pack.git
 cd Obtainium-Emulation-Pack
 
 # Add or edit apps in src/applications.json (or use make add-app)
+make test      # verify configs resolve to real APKs
 make release   # validate, regenerate README, and build release JSONs
 ```

--- a/pages/footer.md
+++ b/pages/footer.md
@@ -9,5 +9,6 @@ git clone https://github.com/RJNY/Obtainium-Emulation-Pack.git
 cd Obtainium-Emulation-Pack
 
 # Add or edit apps in src/applications.json (or use make add-app)
+make test      # verify configs resolve to real APKs
 make release   # validate, regenerate README, and build release JSONs
 ```


### PR DESCRIPTION
## Summary

- Adds `make test` to the Contributing quick start in the README footer
- Validates all three CI jobs pass on a clean change